### PR TITLE
Repair bug: Click more button redirect to 404 page when page number > 1

### DIFF
--- a/layout/mixins/post.jade
+++ b/layout/mixins/post.jade
@@ -15,7 +15,7 @@ mixin posts()
                     +postInfo( item )
                     .post-content
                         != item.excerpt
-                    a.read-more(href=item.path)!= __('more')
+                    a.read-more(href= url_for(item.path))!= __('more')
         - })
 
 //- Post Page


### PR DESCRIPTION
Repair bug: Click more button redirect to 404 page when page number > 1