### PR TITLE
fixed empty excerpt problem

### DIFF
--- a/layout/mixins/post.jade
+++ b/layout/mixins/post.jade
@@ -13,7 +13,7 @@ mixin posts()
                             != item.title
                     +postInfo(item)
                     .post-content
-                        != item.excerpt
+                        != item.excerpt || item.content.replace(/<\/?[^>]+(>|$)/g, "").slice(0,200)
                     a.read-more(href= url_for(item.path))!= __('more')
         - })
 


### PR DESCRIPTION
当文章摘要为空时，用文章文本内容的前200个字符替代。