### PR TITLE
fix navlist display problem on phone

### DIFF
--- a/source/scss/_partial/header.scss
+++ b/source/scss/_partial/header.scss
@@ -1,5 +1,5 @@
 header {
-    height: 60px;
+    min-height: 60px;
 
     .logo-link {
         float: left;


### PR DESCRIPTION
在手机显示时，导航条会折叠到第二行，与文章标题重叠在一起。