### PR TITLE
remove src `#`

### DIFF
--- a/layout/partial/layout.jade
+++ b/layout/partial/layout.jade
@@ -4,7 +4,7 @@ html(lang=config.language)
         include head
     body
         #mask(style="display: none;")
-            img#mask-image(src="#" style=" ")
+            img#mask-image(src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" width="0" height="0" style=" ")
         .wrap
             header
                 a.logo-link(href=url_for())


### PR DESCRIPTION
Firefox and Chrome make a second request when `src="#"`.

![image](https://cloud.githubusercontent.com/assets/5436704/14759776/1759952a-0961-11e6-8dd7-8de530859cae.png)

See more here: http://stackoverflow.com/questions/5775469/whats-the-valid-way-to-include-an-image-with-no-src