### PR TITLE
fix anchor links in post headings

### DIFF
--- a/source/scss/_partial/post.scss
+++ b/source/scss/_partial/post.scss
@@ -30,7 +30,7 @@
     h2, h3, h4, h5, h6 {
         position: relative;
         margin: 1em 0;
-        &:before {
+        a:before {
             content: "#";
             color: #42b983;
             position: absolute;
@@ -41,7 +41,7 @@
         }
     }
     h4, h5, h6 {
-        &:before {
+        a:before {
             content: "";
         }
     }


### PR DESCRIPTION
your theme running the latest Hexo doesn't work because the <a> tag is nested differently than your CSS describes.  This change fixes that.