### PR TITLE
Added support for NetEase cloud tie

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ logo: /favicon.png
 # e.g disqus: seansun
 disqus:
 duoshuo:
+cloudTie:
 
 # Analytics
 # google-analytics:

--- a/layout/partial/comment.jade
+++ b/layout/partial/comment.jade
@@ -25,3 +25,17 @@ if theme.disqus
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
     script(id='dsq-count-scr' src='//#{theme.disqus}.disqus.com/count.js' async)
+
+
+if theme.cloudTie
+    #cloud-tie-wrapper.cloud-tie-wrapper
+    script(src='https://img1.cache.netease.com/f2e/tie/yun/sdk/loader.js')
+    script.
+        var cloudTieConfig = {
+            url: document.location.href,
+            sourceId: "#{page.path}",
+            productKey: "#{theme.cloudTie}",
+            target: "cloud-tie-wrapper"
+        };
+        var yunManualLoad = true;
+        Tie.loader("aHR0cHM6Ly9hcGkuZ2VudGllLjE2My5jb20vcGMvbGl2ZXNjcmlwdC5odG1s", true);


### PR DESCRIPTION
Because duoshuo is going to be abandoned at 1 July 2017, NetEase cloud tie is a good choice, it
supports `https`.

Signed-off-by: XieQirong <cheerx1994@163.com>